### PR TITLE
Fix package.json for CommonJS

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -6,7 +6,6 @@
   "homepage": "https://github.com/abehoffman/bsrp/javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "type": "module",
   "author": "Abe Hoffman",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Because of exporting to CommonJS, this can't be a module package otherwise WebPack (for example) will not recognise it.